### PR TITLE
Chapter Resets

### DIFF
--- a/src/chessChapter.ts
+++ b/src/chessChapter.ts
@@ -167,5 +167,6 @@ export const createChessChapter = (
     isPromotion: () => false,
     isEndOfLine: () => possibleMovesFn(currentMove).length === 0,
     load: load(chess),
+    reset: () => { currentMove.length = 0},
   };
 };

--- a/src/chessStudy.ts
+++ b/src/chessStudy.ts
@@ -12,6 +12,7 @@ export interface ChessChapter extends ChessGame {
   playUserMove(origin: string, destination: string, promotion?: Promotion): GameDelta;
   playAiMove(): GameDelta;
   isEndOfLine(): boolean;
+  reset(): void;
 }
 
 export interface DrawShape {

--- a/src/tests/chessStudy.test.ts
+++ b/src/tests/chessStudy.test.ts
@@ -5,6 +5,20 @@ import { pgnTest, shortPgn } from './pgn';
 import { createChessStudy } from '../chessStudy';
 
 describe('ChessStudy', () => {
+  it('allows user to select a chapter', () => {
+    const chapter = createChessStudy(pgnTest).selectChapter(11);
+
+    expect(chapter).not.toBe(null);
+  });
+
+  it('returns null if chapter does not exist', () => {
+    const chapter = createChessStudy(pgnTest).selectChapter(12);
+
+    expect(chapter).toBe(null);
+  });
+});
+
+describe('ChessChapter', () => {
   it('gives all valid moves from a starting position', () => {
     const chess = new Chess();
     const dests = createChessStudy(pgnTest).selectChapter(11)!.getDests();
@@ -71,4 +85,15 @@ describe('ChessStudy', () => {
       turnColor: 'black',
     });
   });
-});
+
+  it('resets to allow repetition', () => {
+    const chapter = createChessStudy(shortPgn).selectChapter(0)!;
+    [...Array(10).keys()].forEach(() => chapter.playAiMove());
+
+    expect(chapter.isEndOfLine()).toBe(true);
+
+    chapter.reset();
+
+    expect(chapter.isEndOfLine()).toBe(false);
+  });
+})


### PR DESCRIPTION
### Link To Issue:
N/A
### Description of Issue:
When reaching the end of the line in a chapter the user was unable to replay the line or randomize another one.
### Solution:
Add a method on the Chapter Interface called `reset` to clear the current move array.
### Notes:
