### PR TITLE
Fix Changing Chapters

### DIFF
--- a/src/chessChapter.ts
+++ b/src/chessChapter.ts
@@ -149,6 +149,11 @@ const load = (chess: ChessInstance) => (fen: string) => {
   return createDelta(chess);
 };
 
+const reset = (chess: ChessInstance, currentMove: number[]) => () => {
+  chess.reset();
+  currentMove.length = 0;
+}
+
 export const createChessChapter = (
   chess: ChessInstance,
   moves: PgnMove[],
@@ -166,6 +171,6 @@ export const createChessChapter = (
     isPromotion: () => false,
     isEndOfLine: () => possibleMovesFn(currentMove).length === 0,
     load: load(chess),
-    reset: () => { currentMove.length = 0 },
+    reset: reset(chess, currentMove),
   };
 };

--- a/src/chessStudy.ts
+++ b/src/chessStudy.ts
@@ -4,12 +4,11 @@ import { createChessChapter } from './chessChapter';
 import { ChessChapter, ChessStudy } from './types';
 
 export const createChessStudy = (pgn: string): ChessStudy => {
-  const chess = new Chess();
   const chapters = new Map<number, ChessChapter>();
   const parsedPgn = <ParseTree[]>parse(pgn, { startRule: 'games' });
 
   parsedPgn.forEach(({ moves }, index) => {
-    chapters.set(index, createChessChapter(chess, moves));
+    chapters.set(index, createChessChapter(new Chess(), moves));
   });
 
   return {

--- a/src/tests/chessStudy.test.ts
+++ b/src/tests/chessStudy.test.ts
@@ -16,6 +16,19 @@ describe('ChessStudy', () => {
 
     expect(chapter).toBe(null);
   });
+
+
+  it('allows chapter to be changed', () => {
+    const study = createChessStudy(pgnTest);
+    let chapter = study.selectChapter(0)!;
+
+    const delta0 = chapter.playAiMove();
+    chapter = study.selectChapter(11)!
+    const delta1 = chapter.playAiMove();
+
+    expect(delta0.fen).not.toEqual(delta1.fen);
+    expect(delta0.lastMove).not.toEqual(delta1.lastMove);
+  });
 });
 
 describe('ChessChapter', () => {


### PR DESCRIPTION
### Link To Issue:
#16
### Description of Issue:
When using a study and changing chapters the chess instance did not reset.
### Solution:
When changing chapters the chess instance stayed the same. Now, each chapter has its own instance. 
### Notes:
The instance will be reset when chapter is reset.
closes #16