### PR TITLE
fix(game): random moves are now random

### DIFF
--- a/src/chessGame.ts
+++ b/src/chessGame.ts
@@ -43,7 +43,8 @@ const playUserMove =
 const playAiMove = (chess: ChessInstance) => () => {
   const moves = chess.moves({ verbose: true });
 
-  const move = moves[Math.round(Math.random()) * moves.length];
+  const randomIndex = Math.round(Math.random() * moves.length);
+  const move = moves[randomIndex];
 
   chess.move(move);
 

--- a/src/chessGame.ts
+++ b/src/chessGame.ts
@@ -43,7 +43,7 @@ const playUserMove =
 const playAiMove = (chess: ChessInstance) => () => {
   const moves = chess.moves({ verbose: true });
 
-  const move = moves[~~Math.random() * moves.length];
+  const move = moves[Math.round(Math.random()) * moves.length];
 
   chess.move(move);
 

--- a/src/tests/chessGame.test.ts
+++ b/src/tests/chessGame.test.ts
@@ -65,12 +65,10 @@ describe('ChessGame', () => {
     const delta = chessGame.playAiMove();
     chess.move(delta.lastMove);
 
-    expect(delta).toMatchObject({
-      fen: chess.fen(),
-      turnColor: 'black',
-      isCheck: false,
-      dests: possibleMovesToDests(chess),
-    });
+    expect(delta.fen).toEqual(chess.fen());
+    expect(delta.turnColor).toEqual('black');
+    expect(delta.isCheck).toEqual(false);
+    expect(delta.dests).toMatchObject( possibleMovesToDests(chess));
   });
 
   it('does not play invalid move', () => {


### PR DESCRIPTION
### Link To Issue:
#7 
### Description of Issue:
Random moves made by chess game are always the same.
### Solution:
remove ~~ operator that made the move chosen always 0
### Notes:
fixes #7